### PR TITLE
Improve CLI experience: enhanced skills + fix --version/-v flag handling

### DIFF
--- a/.kilo/skills/context7-docs/SKILL.md
+++ b/.kilo/skills/context7-docs/SKILL.md
@@ -2,7 +2,7 @@
 name: context7-docs
 description: Get documentation for a library from Context7. Use when you need up-to-date library documentation, API references, code examples, or specific topic information from Context7.
 license: MIT
-compatibility: Requires Node.js >=18 and the @vedanth/context7 package installed
+compatibility: Requires Node.js >=18. The @vedanth/context7 CLI can be installed globally, installed as a project dependency, or used via npx (zero install).
 metadata:
   author: Kilo
   version: "1.0.1"
@@ -187,10 +187,13 @@ Common issues and solutions:
 
 3. **With Editor Integration**
    ```bash
-   # Create helper scripts for your editor
-   echo '#!/bin/bash\nc7 "$@"' > ~/bin/context7-search
-   chmod +x ~/bin/context7-search
-   ```
+    # Create helper scripts for your editor
+    cat > ~/bin/context7-search << 'SCRIPT'
+#!/bin/bash
+c7 "$@"
+SCRIPT
+    chmod +x ~/bin/context7-search
+    ```
 
 ### Use Cases
 

--- a/.kilo/skills/context7-docs/SKILL.md
+++ b/.kilo/skills/context7-docs/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: context7-docs
+description: Get documentation for a library from Context7. Use when you need up-to-date library documentation, API references, code examples, or specific topic information from Context7.
+license: MIT
+compatibility: Requires Node.js >=18 and the @vedanth/context7 package installed
+metadata:
+  author: Kilo
+  version: "1.0.1"
+allowed-tools: Bash
+---
+
+# Context7 Documentation Fetch Skill
+
+This skill provides instructions for fetching library documentation using the c7 CLI tool from Context7.
+
+## Overview
+
+Context7 provides version-specific, up-to-date documentation for programming libraries and frameworks. This skill helps you retrieve documentation directly from the terminal.
+
+## How to Use
+
+### Basic Documentation Fetch
+
+```bash
+# Using docs subcommand explicitly
+c7 docs <library> [topic]
+
+# Using shorthand syntax (more convenient)
+c7 <library> [topic]
+
+# Using with npx (no installation required)
+npx @vedanth/context7 <library> [topic]
+```
+
+### Options
+
+- `--tokens <n>`: Maximum tokens to return (default: 5000)
+- `--api-key <key>`: Provide Context7 API key (or set CONTEXT7_API_KEY environment variable)
+
+### Examples
+
+```bash
+# Get React hooks documentation (using shorthand)
+c7 react hooks
+
+# Get React hooks documentation (using explicit docs subcommand)
+c7 docs react hooks
+
+# Get Next.js app router docs with more tokens
+c7 docs nextjs "app router" --tokens 10000
+
+# Get Express middleware documentation
+c7 express middleware
+
+# Get Tailwind CSS dark mode docs
+c7 tailwindcss "dark mode"
+
+# Use exact Context7 ID
+c7 docs /vercel/next.js "image optimization"
+
+# Use with npx (no installation required)
+npx @vedanth/context7 vue "composition api"
+```
+
+### Advanced Usage
+
+#### Piping Output
+
+```bash
+# Copy to clipboard (macOS)
+c7 react hooks | pbcopy
+
+# Copy to clipboard (Linux)
+c7 react hooks | xclip -selection clipboard
+
+# Save to file
+c7 express middleware >> docs.txt
+
+# Feed into LLM (if claude command is available)
+c7 nextjs "api routes" | claude "summarize these docs"
+
+# Process with other CLI tools
+c7 react "component lifecycle" | grep -A 5 -B 5 "useEffect"
+```
+
+#### Environment Variable
+
+Set your API key for higher rate limits:
+
+```bash
+export CONTEXT7_API_KEY=your-api-key-here
+```
+
+### Output Format
+
+Returns plain text documentation that can be piped to other tools, saved to files, or used in scripts.
+
+### Practical Use Cases
+
+1. **Quick API Reference Lookup**
+   ```bash
+   # Quickly find method signatures
+   c7 lodash "debounce" | head -10
+   ```
+
+2. **Integration With Coding Assistants**
+   ```bash
+   # Create a contextual prompt for an AI
+   c7 express "middleware" > express-middleware-docs.txt
+   echo "Using the following documentation, help me create middleware:" | cat - express-middleware-docs.txt | claude
+   ```
+
+3. **Automated Documentation Workflows**
+   ```bash
+   # Generate documentation snippets for a project
+   mkdir project-docs
+   c7 react "hooks" > project-docs/react-hooks.md
+   c7 redux "selectors" > project-docs/redux-selectors.md
+   ```
+
+### Error Handling
+
+- If the library name can't be resolved automatically, use `c7 resolve` first to find the exact ID
+- For version-specific docs, use the full Context7 ID path like `/vercel/next.js`
+- Check your API key if you hit rate limits
+- If getting "command not found" errors, ensure the CLI is properly installed or use npx
+
+### Installation Options
+
+Choose the best installation method for your needs:
+
+```bash
+# Option 1: Global installation (recommended for frequent use)
+npm install -g @vedanth/context7
+
+# Option 2: Use with npx (no installation required)
+npx @vedanth/context7 <library> [topic]
+
+# Option 3: Install as a project dependency
+npm install @vedanth/context7 --save-dev
+```
+
+### Troubleshooting
+
+Common issues and solutions:
+
+1. **"command not found"**: Install globally or use npx:
+   ```bash
+   # Install globally
+   npm install -g @vedanth/context7
+   
+   # Or use npx for one-time use
+   npx @vedanth/context7 react hooks
+   ```
+
+2. **"No libraries found"**: The library name might differ from common assumptions:
+   ```bash
+   # Search for alternative names
+   c7 resolve vue
+   c7 resolve angular
+   ```
+
+3. **Rate limiting**: Set an API key to increase rate limits:
+   ```bash
+   export CONTEXT7_API_KEY=your-key-here
+   # Add to ~/.zshrc or ~/.bashrc for persistence
+   echo 'export CONTEXT7_API_KEY=your-key-here' >> ~/.zshrc
+   ```
+
+### Integration with Development Workflows
+
+1. **In Package.json Scripts**
+   ```json
+   {
+     "scripts": {
+       "docs-react": "c7 react 'hooks guide' > docs/react-hooks.md",
+       "docs-express": "c7 express middleware > docs/express-middleware.md"
+     }
+   }
+   ```
+
+2. **In CI/CD Pipelines**
+   ```bash
+   # Generate documentation artifacts during build
+   c7 "$FRAMEWORK" "best practices" > docs/$FRAMEWORK-best-practices.md
+   ```
+
+3. **With Editor Integration**
+   ```bash
+   # Create helper scripts for your editor
+   echo '#!/bin/bash\nc7 "$@"' > ~/bin/context7-search
+   chmod +x ~/bin/context7-search
+   ```
+
+### Use Cases
+
+- Quick API reference lookup
+- Getting code examples for specific features
+- Comparing documentation across versions
+- Feeding documentation into AI coding assistants
+- Building documentation into automation scripts
+- Creating project-specific documentation bundles
+- Onboarding new team members with relevant docs

--- a/.kilo/skills/context7-resolve/SKILL.md
+++ b/.kilo/skills/context7-resolve/SKILL.md
@@ -2,7 +2,7 @@
 name: context7-resolve
 description: Find Context7 library IDs for a given library name. Use when you need to resolve library names to their Context7 identifiers for documentation retrieval.
 license: MIT
-compatibility: Requires Node.js >=18 and the @vedanth/context7 package installed
+compatibility: Requires Node.js >=18. The @vedanth/context7 CLI can be installed globally, installed as a project dependency, or used via npx (zero install).
 metadata:
   author: Kilo
   version: "1.0.1"
@@ -94,7 +94,7 @@ When using `--json`, returns an array of results:
 
 ```bash
 # Resolve, extract ID, then fetch docs
-ID=$(c7 resolve react --json | node -e "process.stdin.on('data',d=>console.log(JSON.parse(d)[0].id))")
+ID=$(c7 resolve react --json | node -e "const d=require('fs').readFileSync('/dev/stdin','utf8');process.stdout.write(JSON.parse(d)[0].id)")
 c7 docs "$ID" "hooks"
 ```
 
@@ -150,7 +150,7 @@ resolve-lib:
 		data.forEach(r => console.log(r.id, '-', r.description));"
 
 docs:
-	c7 docs $(shell c7 resolve $(LIB) --json | node -e "process.stdin.on('data',d=>console.log(JSON.parse(d)[0].id))") "$(TOPIC)"
+	c7 docs $(shell c7 resolve $(LIB) --json | node -e "const d=require('fs').readFileSync('/dev/stdin','utf8');process.stdout.write(JSON.parse(d)[0].id)") "$(TOPIC)"
 ```
 
 #### In Automation Scripts
@@ -160,7 +160,7 @@ docs:
 # fetch-docs.sh — resolve and fetch docs in one step
 LIB=$1
 TOPIC=$2
-ID=$(npx @vedanth/context7 r "$LIB" --json | node -e "process.stdin.on('data',d=>console.log(JSON.parse(d)[0].id))")
+ID=$(npx @vedanth/context7 r "$LIB" --json | node -e "const d=require('fs').readFileSync('/dev/stdin','utf8');process.stdout.write(JSON.parse(d)[0].id)")
 npx @vedanth/context7 docs "$ID" "$TOPIC"
 ```
 

--- a/.kilo/skills/context7-resolve/SKILL.md
+++ b/.kilo/skills/context7-resolve/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: context7-resolve
+description: Find Context7 library IDs for a given library name. Use when you need to resolve library names to their Context7 identifiers for documentation retrieval.
+license: MIT
+compatibility: Requires Node.js >=18 and the @vedanth/context7 package installed
+metadata:
+  author: Kilo
+  version: "1.0.1"
+allowed-tools: Bash
+---
+
+# Context7 Library Resolution Skill
+
+This skill provides instructions for resolving library names to Context7 identifiers using the c7 CLI tool.
+
+## Overview
+
+Context7 provides version-specific, up-to-date library documentation. Resolving a library name converts common names (e.g. "nextjs", "react") into Context7 canonical IDs (e.g. `/vercel/next.js`, `/facebook/react`), which can then be used with `c7 docs` for targeted documentation retrieval.
+
+## When to Use This Skill
+
+Use this skill when:
+
+- You know the common name of a library but `c7 docs <name>` fails with "No libraries found"
+- You need to find the exact Context7 ID for version-specific or vendor-scoped documentation
+- You want to see what libraries are available before choosing one
+- You need to explore alternative naming conventions for a library
+
+## How to Use
+
+### Basic Resolution
+
+```bash
+c7 resolve <library-name>
+
+# Using shorthand alias
+c7 r <library-name>
+
+# Using with npx (no installation required)
+npx @vedanth/context7 resolve <library-name>
+
+# Using shorthand alias with npx
+npx @vedanth/context7 r <library-name>
+```
+
+### Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--json` | Output raw JSON instead of formatted text | off |
+| `--api-key <key>` | Context7 API key (or set CONTEXT7_API_KEY env var) | none |
+
+### Examples
+
+```bash
+# Simple lookup
+c7 resolve nextjs
+# → /vercel/next.js
+
+# Resolve with JSON output for programmatic use
+c7 resolve react --json
+
+# Disambiguate between similar libraries
+c7 resolve express
+c7 resolve koa
+
+# Explore available libraries
+c7 resolve state management
+c7 resolve css framework
+
+# Non-obvious naming
+c7 resolve rn  # React Native
+c7 resolve nv  # Neovim
+c7 resolve shadcn
+```
+
+### JSON Output Format
+
+When using `--json`, returns an array of results:
+
+```json
+[
+  {
+    "id": "/facebook/react",
+    "title": "React",
+    "description": "A JavaScript library for building user interfaces"
+  }
+]
+```
+
+### Working with Resolve Results
+
+#### Chain with docs in a script
+
+```bash
+# Resolve, extract ID, then fetch docs
+ID=$(c7 resolve react --json | node -e "process.stdin.on('data',d=>console.log(JSON.parse(d)[0].id))")
+c7 docs "$ID" "hooks"
+```
+
+#### Use shorthands for known libraries
+
+Once you know the ID, you can use it directly:
+
+```bash
+c7 docs /facebook/react hooks
+c7 docs /vercel/next.js "app router"
+```
+
+### Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| "No libraries found for X" | Library not in Context7 index | Try synonyms, check spelling, or use a more general query |
+| "Search failed: 429" | Rate limited | Set `CONTEXT7_API_KEY` for higher limits |
+| "Error: fetch failed" | Network issue | Check internet connection |
+| "command not found: c7" | CLI not installed | Use `npx @vedanth/context7` or run `npm install -g @vedanth/context7` |
+
+### When Resolution Fails
+
+If `c7 resolve` returns no results, try these strategies in order:
+
+1. **Use a more general name**: `react` → `reactjs`, `vue` → `vuejs`
+2. **Try the ecosystem name**: `chakra` → `chakra-ui`, `tailwind` → `tailwindcss`
+3. **Search by category**: `c7 resolve css framework` or `c7 resolve react component library`
+4. **Use the library's GitHub org/repo name**: Look at the library's GitHub URL and try `/org/repo` format
+5. **Check if it needs version qualification**: Some libraries have multiple version IDs
+
+### Installation Options
+
+```bash
+# Global install (recommended for frequent use)
+npm install -g @vedanth/context7
+
+# Use with npx (zero install)
+npx @vedanth/context7 resolve <library>
+
+# Project install
+npm install @vedanth/context7 --save-dev
+```
+
+### Integration Patterns
+
+#### In Makefile
+
+```makefile
+resolve-lib:
+	@c7 resolve $(LIB) --json | node -e "\
+		const data = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));\
+		data.forEach(r => console.log(r.id, '-', r.description));"
+
+docs:
+	c7 docs $(shell c7 resolve $(LIB) --json | node -e "process.stdin.on('data',d=>console.log(JSON.parse(d)[0].id))") "$(TOPIC)"
+```
+
+#### In Automation Scripts
+
+```bash
+#!/usr/bin/env bash
+# fetch-docs.sh — resolve and fetch docs in one step
+LIB=$1
+TOPIC=$2
+ID=$(npx @vedanth/context7 r "$LIB" --json | node -e "process.stdin.on('data',d=>console.log(JSON.parse(d)[0].id))")
+npx @vedanth/context7 docs "$ID" "$TOPIC"
+```
+
+### Frequently Resolved Libraries
+
+| Common Name | Context7 ID |
+|-------------|-------------|
+| react | `/facebook/react` |
+| nextjs | `/vercel/next.js` |
+| express | `/expressjs/express` |
+| tailwindcss | `/tailwindlabs/tailwindcss` |
+| vue | `/vuejs/core` |
+| prisma | `/prisma/prisma` |
+| lodash | `/lodash/lodash` |
+| axios | `/axios/axios` |

--- a/.kilo/skills/pr-review-loop/SKILL.md
+++ b/.kilo/skills/pr-review-loop/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: pr-review-loop
+description: After creating a PR, check for automated review comments (copilot, coderabbit, etc.), fix issues, commit, push, and reply. Use after any PR is opened to ensure all review feedback is addressed before merge.
+license: MIT
+compatibility: Requires GitHub CLI (gh) authenticated and git push access to a fork remote
+metadata:
+  author: Kilo
+  version: "1.0.0"
+allowed-tools: Bash
+---
+
+# PR Review Loop Skill
+
+This skill codifies the workflow of responding to automated PR review comments (GitHub Copilot, CodeRabbit, etc.) after opening a pull request.
+
+## When to Use
+
+Use this skill immediately after creating a PR, before requesting human reviews. It ensures all automated review feedback is addressed so human reviewers see a clean, iterated diff.
+
+## Flow
+
+### 1. Fetch Review Comments
+
+```bash
+# Fetch all inline review comments on the PR
+gh api repos/{owner}/{repo}/pulls/{pr-number}/comments --paginate | jq '.[] | {path, line, body, author: .user.login}'
+
+# Fetch overall review summaries
+gh pr view {pr-number} --repo {owner}/{repo} --comments --json comments,reviews | jq '.reviews[] | {author: .author.login, body, state, submittedAt}'
+```
+
+### 2. Categorize Comments
+
+Group comments into categories:
+
+| Category | Examples | Action |
+|----------|----------|--------|
+| **Code correctness** | Chunked stdin parsing, portable scripts | Fix immediately |
+| **Documentation/accuracy** | Compatibility claims, version numbers | Update to reflect reality |
+| **Style/formatting** | Markdown table syntax, indentation | Fix to match conventions |
+| **Scope concerns** | PR says X but only does Y | Update PR body or add missing changes |
+| **Out of scope** | Suggestions for unrelated improvements | Acknowledge, defer to separate PR |
+
+### 3. Fix Each Issue
+
+For each fix:
+
+```bash
+# Read the file at the reported line
+# Apply the fix using the Edit tool
+
+# Stage the fix
+git add <file>
+
+# After all fixes are applied, commit
+git commit -m "fix: address review comments — brief description of what was fixed"
+```
+
+### 4. Push and Reply
+
+```bash
+git push fork <branch-name>
+```
+
+Then reply on the PR summarizing what was addressed:
+
+```bash
+gh pr comment {pr-number} --repo {owner}/{repo} --body "All review comments addressed in {commit-sha}:
+
+- **Issue 1**: Description of fix
+- **Issue 2**: Description of fix
+..."
+```
+
+### 5. Common Patterns
+
+#### Chunked stdin JSON parsing (unsafe → safe)
+
+```
+# Unsafe — can fail on chunked stdin:
+node -e "process.stdin.on('data',d=>console.log(JSON.parse(d)[0].id))"
+
+# Safe — reads full stdin before parsing:
+node -e "const d=require('fs').readFileSync('/dev/stdin','utf8');console.log(JSON.parse(d)[0].id)"
+```
+
+#### Portable script writing (echo → heredoc)
+
+```
+# Unsafe — \\n escaping not portable across shells:
+echo '#!/bin/bash\\nc7 "$@"' > script.sh
+
+# Safe — heredoc:
+cat > script.sh << 'SCRIPT'
+#!/bin/bash
+c7 "$@"
+SCRIPT
+```
+
+#### Version bump for re-publish
+
+If a PR fixes a bug in a published npm package, bump the version:
+
+```bash
+# bump patch in package.json
+node -e "const p=require('./package.json');const v=p.version.split('.');v[2]=Number(v[2])+1;p.version=v.join('.');require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')"
+```
+
+## Checklist
+
+- [ ] PR is open and has automated reviews
+- [ ] Fetched all inline comments and review summaries
+- [ ] Categorized each issue
+- [ ] Applied fixes for all actionable items
+- [ ] Committed and pushed
+- [ ] Replied on PR with summary of addressed issues

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vedanth/context7",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "CLI for Context7 — get up-to-date, version-specific library docs from your terminal",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Two changes to improve the Context7 CLI developer experience:

### 1. Enhanced .kilo/skills/ (CLI Agent Skills)

Improves both context7-docs and context7-resolve skills with:
- npx usage across all examples, shorthand aliases
- Pipe mode patterns (clipboard, grep, file output)
- Structured error handling tables with specific fixes
- Automation patterns (Makefile, CI/CD, package.json scripts)
- Troubleshooting sections with step-by-step recovery
- Practical use cases and integration workflows

### 2. Fix: --version / -v Flag Handling (bin/c7.js)

The npm-published v1.0.2 of @vedanth/context7 is missing --version/-v flag support. The fix already exists in the repo source but was omitted from the npm tarball. Two blocks need inclusion in the next npm publish:

1. In parseArgs(): the --version/-v branch after the --json branch
2. In main(): the opts.version early-exit block before the help check

## Related
Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Context7 Documentation Fetch skill: enables documentation retrieval via CLI with comprehensive usage, options, and workflow examples.
  * Added Context7 Library Resolution skill: enables library name resolution to canonical identifiers with JSON output and integration guidance for automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->